### PR TITLE
Add error argument to all Hook calls

### DIFF
--- a/counterhook.go
+++ b/counterhook.go
@@ -77,56 +77,56 @@ func (h *CounterHook) RowsIterated() int {
 }
 
 // ConnOpened implements ConnOpened of the Hook interface.
-func (h *CounterHook) ConnOpened() {
+func (h *CounterHook) ConnOpened(err error) {
 	atomic.AddInt64(&h.openConns, 1)
 	atomic.AddInt64(&h.totalConns, 1)
 }
 
 // ConnClosed implements ConnClosed of the Hook interface.
-func (h *CounterHook) ConnClosed() {
+func (h *CounterHook) ConnClosed(err error) {
 	atomic.AddInt64(&h.openConns, -1)
 }
 
 // StmtPrepared implements StmtPrepared of the Hook interface.
-func (h *CounterHook) StmtPrepared(query string) {
+func (h *CounterHook) StmtPrepared(query string, err error) {
 	atomic.AddInt64(&h.openStmts, 1)
 	atomic.AddInt64(&h.totalStmts, 1)
 }
 
 // StmtClosed implements StmtClosed of the Hook interface.
-func (h *CounterHook) StmtClosed() {
+func (h *CounterHook) StmtClosed(err error) {
 	atomic.AddInt64(&h.openStmts, -1)
 }
 
 // TxBegan implements TxBegan of the Hook interface.
-func (h *CounterHook) TxBegan() {
+func (h *CounterHook) TxBegan(err error) {
 	atomic.AddInt64(&h.openTxs, 1)
 	atomic.AddInt64(&h.totalTxs, 1)
 }
 
 // TxCommitted implements TxCommitted of the Hook interface.
-func (h *CounterHook) TxCommitted() {
+func (h *CounterHook) TxCommitted(err error) {
 	atomic.AddInt64(&h.openTxs, -1)
 	atomic.AddInt64(&h.committedTxs, 1)
 }
 
 // TxRolledback implements TxRolledback of the Hook interface.
-func (h *CounterHook) TxRolledback() {
+func (h *CounterHook) TxRolledback(err error) {
 	atomic.AddInt64(&h.openTxs, -1)
 	atomic.AddInt64(&h.rolledbackTxs, 1)
 }
 
 // Queried implements Queried of the Hook interface.
-func (h *CounterHook) Queried(d time.Duration, query string) {
+func (h *CounterHook) Queried(d time.Duration, query string, err error) {
 	atomic.AddInt64(&h.queries, 1)
 }
 
 // Execed implements Execed of the Hook interface.
-func (h *CounterHook) Execed(d time.Duration, query string) {
+func (h *CounterHook) Execed(d time.Duration, query string, err error) {
 	atomic.AddInt64(&h.execs, 1)
 }
 
 // RowIterated implements RowIterated of the Hook interface.
-func (h *CounterHook) RowIterated() {
+func (h *CounterHook) RowIterated(err error) {
 	atomic.AddInt64(&h.rowsIterated, 1)
 }

--- a/counterhook.go
+++ b/counterhook.go
@@ -19,6 +19,14 @@ type CounterHook struct {
 	queries       int64
 	execs         int64
 	rowsIterated  int64
+
+	connErrs    int64
+	stmtErrs    int64
+	txOpenErrs  int64
+	txCloseErrs int64
+	queryErrs   int64
+	execErrs    int64
+	rowErrs     int64
 }
 
 // OpenConns returns the current count of open connections.
@@ -76,10 +84,50 @@ func (h *CounterHook) RowsIterated() int {
 	return int(atomic.LoadInt64(&h.rowsIterated))
 }
 
+// ConnErrs returns the number of errors encountered trying to open a connection.
+func (h *CounterHook) ConnErrs() int {
+	return int(atomic.LoadInt64(&h.connErrs))
+}
+
+// StmtErrs returns the number of errors encountered trying to prepare a statement.
+func (h *CounterHook) StmtErrs() int {
+	return int(atomic.LoadInt64(&h.stmtErrs))
+}
+
+// TxOpenErrs returns the number of errors encountered trying to start a transaction.
+func (h *CounterHook) TxOpenErrs() int {
+	return int(atomic.LoadInt64(&h.txOpenErrs))
+}
+
+// TxCloseErrs returns the number of errors encountered trying to Commit or Rollback
+// a transacttion.
+func (h *CounterHook) TxCloseErrs() int {
+	return int(atomic.LoadInt64(&h.txCloseErrs))
+}
+
+// QueryErrs returns the number of errors encountered trying to run a query.
+func (h *CounterHook) QueryErrs() int {
+	return int(atomic.LoadInt64(&h.queryErrs))
+}
+
+// ExexErrs returns the number of errors encountered trying to exec command.
+func (h *CounterHook) ExecErrs() int {
+	return int(atomic.LoadInt64(&h.execErrs))
+}
+
+// RowErrs returns the number of error encountered while iterating rows.
+func (h *CounterHook) RowErrs() int {
+	return int(atomic.LoadInt64(&h.rowErrs))
+}
+
 // ConnOpened implements ConnOpened of the Hook interface.
 func (h *CounterHook) ConnOpened(err error) {
-	atomic.AddInt64(&h.openConns, 1)
-	atomic.AddInt64(&h.totalConns, 1)
+	if err == nil {
+		atomic.AddInt64(&h.openConns, 1)
+		atomic.AddInt64(&h.totalConns, 1)
+	} else {
+		atomic.AddInt64(&h.connErrs, 1)
+	}
 }
 
 // ConnClosed implements ConnClosed of the Hook interface.
@@ -89,8 +137,12 @@ func (h *CounterHook) ConnClosed(err error) {
 
 // StmtPrepared implements StmtPrepared of the Hook interface.
 func (h *CounterHook) StmtPrepared(query string, err error) {
-	atomic.AddInt64(&h.openStmts, 1)
-	atomic.AddInt64(&h.totalStmts, 1)
+	if err == nil {
+		atomic.AddInt64(&h.openStmts, 1)
+		atomic.AddInt64(&h.totalStmts, 1)
+	} else {
+		atomic.AddInt64(&h.stmtErrs, 1)
+	}
 }
 
 // StmtClosed implements StmtClosed of the Hook interface.
@@ -100,33 +152,57 @@ func (h *CounterHook) StmtClosed(err error) {
 
 // TxBegan implements TxBegan of the Hook interface.
 func (h *CounterHook) TxBegan(err error) {
-	atomic.AddInt64(&h.openTxs, 1)
-	atomic.AddInt64(&h.totalTxs, 1)
+	if err == nil {
+		atomic.AddInt64(&h.openTxs, 1)
+		atomic.AddInt64(&h.totalTxs, 1)
+	} else {
+		atomic.AddInt64(&h.txOpenErrs, 1)
+	}
 }
 
 // TxCommitted implements TxCommitted of the Hook interface.
 func (h *CounterHook) TxCommitted(err error) {
 	atomic.AddInt64(&h.openTxs, -1)
-	atomic.AddInt64(&h.committedTxs, 1)
+	if err == nil {
+		atomic.AddInt64(&h.committedTxs, 1)
+	} else {
+		atomic.AddInt64(&h.txCloseErrs, 1)
+	}
 }
 
 // TxRolledback implements TxRolledback of the Hook interface.
 func (h *CounterHook) TxRolledback(err error) {
 	atomic.AddInt64(&h.openTxs, -1)
-	atomic.AddInt64(&h.rolledbackTxs, 1)
+	if err == nil {
+		atomic.AddInt64(&h.rolledbackTxs, 1)
+	} else {
+		atomic.AddInt64(&h.txCloseErrs, 1)
+	}
 }
 
 // Queried implements Queried of the Hook interface.
 func (h *CounterHook) Queried(d time.Duration, query string, err error) {
-	atomic.AddInt64(&h.queries, 1)
+	if err == nil {
+		atomic.AddInt64(&h.queries, 1)
+	} else {
+		atomic.AddInt64(&h.queryErrs, 1)
+	}
 }
 
 // Execed implements Execed of the Hook interface.
 func (h *CounterHook) Execed(d time.Duration, query string, err error) {
-	atomic.AddInt64(&h.execs, 1)
+	if err == nil {
+		atomic.AddInt64(&h.execs, 1)
+	} else {
+		atomic.AddInt64(&h.execErrs, 1)
+	}
 }
 
 // RowIterated implements RowIterated of the Hook interface.
 func (h *CounterHook) RowIterated(err error) {
-	atomic.AddInt64(&h.rowsIterated, 1)
+	if err == nil {
+		atomic.AddInt64(&h.rowsIterated, 1)
+	} else {
+		atomic.AddInt64(&h.rowErrs, 1)
+	}
 }

--- a/counterhook_test.go
+++ b/counterhook_test.go
@@ -8,7 +8,7 @@ import (
 func TestCounterHookConnections(t *testing.T) {
 	h := &CounterHook{}
 
-	h.ConnOpened()
+	h.ConnOpened(nil)
 	if h.OpenConns() != 1 {
 		t.Errorf("Expected ConnOpened to increment OpenConns to 1, got %d", h.OpenConns())
 	}
@@ -16,7 +16,7 @@ func TestCounterHookConnections(t *testing.T) {
 		t.Errorf("Expected ConnOpened to increment TotalConns to 1, got %d", h.TotalConns())
 	}
 
-	h.ConnClosed()
+	h.ConnClosed(nil)
 	if h.OpenConns() != 0 {
 		t.Errorf("Expected ConnClosed to decrement OpenConns to 0, got %d", h.OpenConns())
 	}
@@ -28,7 +28,7 @@ func TestCounterHookConnections(t *testing.T) {
 func TestCounterHookStatements(t *testing.T) {
 	h := &CounterHook{}
 
-	h.StmtPrepared("SELECT 1")
+	h.StmtPrepared("SELECT 1", nil)
 	if h.OpenStmts() != 1 {
 		t.Errorf("Expected StmtPrepared to increment OpenStmts to 1, got %d", h.OpenStmts())
 	}
@@ -36,7 +36,7 @@ func TestCounterHookStatements(t *testing.T) {
 		t.Errorf("Expected StmtPrepared to increment TotalStmts to 1, got %d", h.TotalStmts())
 	}
 
-	h.StmtClosed()
+	h.StmtClosed(nil)
 	if h.OpenStmts() != 0 {
 		t.Errorf("Expected StmtClosed to decrement OpenStmts to 0, got %d", h.OpenStmts())
 	}
@@ -48,7 +48,7 @@ func TestCounterHookStatements(t *testing.T) {
 func TestCounterHookTransactions(t *testing.T) {
 	h := &CounterHook{}
 
-	h.TxBegan()
+	h.TxBegan(nil)
 	if h.OpenTxs() != 1 {
 		t.Errorf("Expected TxBegan to increment OpenTxs to 1, got %d", h.OpenTxs())
 	}
@@ -56,7 +56,7 @@ func TestCounterHookTransactions(t *testing.T) {
 		t.Errorf("Expected TxBegan to increment TotalTxs to 1, got %d", h.TotalTxs())
 	}
 
-	h.TxCommitted()
+	h.TxCommitted(nil)
 	if h.OpenTxs() != 0 {
 		t.Errorf("Expected TxCommitted to decrement OpenTxs to 0, got %d", h.OpenTxs())
 	}
@@ -67,8 +67,8 @@ func TestCounterHookTransactions(t *testing.T) {
 		t.Errorf("Expected TxCommitted to increment CommittedTxs to 1, got %d", h.CommittedTxs())
 	}
 
-	h.TxBegan()
-	h.TxRolledback()
+	h.TxBegan(nil)
+	h.TxRolledback(nil)
 	if h.OpenTxs() != 0 {
 		t.Errorf("Expected TxRolledback to decrement OpenTxs to 0, got %d", h.OpenTxs())
 	}
@@ -83,17 +83,17 @@ func TestCounterHookTransactions(t *testing.T) {
 func TestCounterHookQueriesExecsRows(t *testing.T) {
 	h := &CounterHook{}
 
-	h.Queried(time.Millisecond*10, "SELECT 1")
+	h.Queried(time.Millisecond*10, "SELECT 1", nil)
 	if h.Queries() != 1 {
 		t.Errorf("Expected Queried to increment Queries to 1, got %d", h.Queries())
 	}
 
-	h.Execed(time.Millisecond, "UPDATE my_table SET myvar=?")
+	h.Execed(time.Millisecond, "UPDATE my_table SET myvar=?", nil)
 	if h.Execs() != 1 {
 		t.Errorf("Expected Execed to increment Execs to 1, got %d", h.Execs())
 	}
 
-	h.RowIterated()
+	h.RowIterated(nil)
 	if h.RowsIterated() != 1 {
 		t.Errorf("Expected RowIterated to increment RowsIterated to 1, got %d", h.RowsIterated())
 	}


### PR DESCRIPTION
As requested in #3.

After a lot of thinking about it, I came to the decision that having the context of the error in the callback and having the `Hook` implementor decide how they want to handle counting when an error occurs is the best way to handle this. As opposed to having a separate `ErrorHook` interface.
